### PR TITLE
pfelk_rule_generator.sh rm extra after rule name

### DIFF
--- a/etc/pfelk/scripts/pfelk_rule_generator.sh
+++ b/etc/pfelk/scripts/pfelk_rule_generator.sh
@@ -77,7 +77,7 @@ firewall_opt(){
 }
 
 opnsense_pfctl(){
-  pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})"/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
+  pfctl -vv -sr | grep label | sed -r 's/@([[:digit:]]+).*"([^"]{32})".*/"\2","\1"/g' | sort -k 1.1 > /tmp/pfelk_rules_pfctl.tmp
 }
 
 opnsense_opt1(){


### PR DESCRIPTION
When using tags in opnsense the tag is added after the rule name label "char(32)" tag MYTAG_NAME
also when using the tag as a filter inside rules
label "char(32)" tagged MYTAG_NAME

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Original Configuration
- [ ] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version:
* Linux Version/Type:
* Java Version:
* Elastic Stack Configuration Files:

## Checklist:

- [ ] Code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
